### PR TITLE
Upgrade to Module syntax. Upgrade to ToucanJS 4.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,35 +13,32 @@ npm install -D @cloudflare/worker-sentry
 ```js
 import { initSentry } from "@cloudflare/worker-sentry";
 
-addEventListener("fetch", (event) => {
-  const sentry = initSentry(event);
-  event.respondWith(handleRequest(event, sentry));
-});
+export default {
+  async fetch(request, env, context) {
+    const sentry = initSentry(request, env, context);
 
-async function handleRequest(request, sentry) {
-  try {
-    console.log("Got request", request);
-    const response = await fetch(request);
-    console.log("Got response", response);
-    return response;
-  } catch (e) {
-    sentry.captureException(e);
-    return new Response("internal error", { status: 500 });
+    try {
+      console.log("Got request", request);
+      const response = await fetch(request);
+      console.log("Got response", response);
+      return response;
+    } catch (e) {
+      sentry.captureException(e);
+      return new Response("internal error", { status: 500 });
+    }
   }
-}
+} 
 ```
 
 ## Additional `toucan-js` options
 
-The API: `initSentry(event, additionalOptions = {})` allows any options to be passed directly to `toucan-js`. For instance to specify the `environment` the worker is running in.
+The API: `initSentry(request, env, context, additionalOptions = {})` allows any options to be passed directly to `toucan-js`. For instance to specify the `environment` the worker is running in.
 
 ## Usage with wrangler
 
 ```toml
 name = "sentry-test"
-type = "webpack"
 account_id = "your account_id"
-workers_dev = true
 
 [vars]
 SENTRY_DSN = "Sentry DSN"

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,9 @@
+import { Toucan, Options } from "toucan-js";
+
+interface Env {
+    SENTRY_DSN: string,
+    SENTRY_CLIENT_ID: string,
+    SENTRY_CLIENT_SECRET: string,
+}
+
+export function initSentry(request: Request, env: Env, context: ExecutionContext, additionalOptions: Options = {}): Toucan;

--- a/index.mjs
+++ b/index.mjs
@@ -1,11 +1,10 @@
-import Toucan from 'toucan-js';
+import { rewriteFramesIntegration, Toucan } from 'toucan-js';
 
-export function initSentry(event, additionalOptions = {}) {
-  const request = event.request;
-
+export function initSentry(request, env, context, additionalOptions = {}) {
   const sentry = new Toucan({
-    dsn: SENTRY_DSN,
-    event: event,
+    dsn: env.SENTRY_DSN,
+    context,
+    request,
     allowedHeaders: [
       'user-agent',
       'cf-challenge',
@@ -18,13 +17,13 @@ export function initSentry(event, additionalOptions = {}) {
       'host',
     ],
     allowedSearchParams: /(.*)/,
-    rewriteFrames: {
-      root: '/',
-    },
+    integrations: [
+      rewriteFramesIntegration({root: "/"})
+    ],
     transportOptions: {
       headers: {
-        'CF-Access-Client-ID': SENTRY_CLIENT_ID,
-        'CF-Access-Client-Secret': SENTRY_CLIENT_SECRET,
+        'CF-Access-Client-ID': env.SENTRY_CLIENT_ID,
+        'CF-Access-Client-Secret': env.SENTRY_CLIENT_SECRET,
       },
     },
     ...additionalOptions

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cloudflare/worker-sentry",
-  "version": "1.0.1",
-  "description": "Intergation with Sentry over Access for Worker",
+  "version": "2.0.0",
+  "description": "Integration with Sentry over Access for Worker",
   "main": "index.mjs",
   "type": "module",
   "scripts": {
@@ -14,6 +14,9 @@
   "author": "cloudflare",
   "license": "MIT",
   "dependencies": {
-    "toucan-js": "^2.2.0"
+    "toucan-js": "^4.1.1"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240405.0"
   }
 }


### PR DESCRIPTION
This PR does three things, and is a breaking change:
1. moves from the legacy syntax to the worker module syntax (fixes #5)
2. adds typescript type declarations (#7)
3. upgrades the usage of the underlying Toucan library to use the latest major version (Toucan ~4)
